### PR TITLE
Change configure_dmc to use a var 

### DIFF
--- a/roles/splunk/defaults/main.yml
+++ b/roles/splunk/defaults/main.yml
@@ -51,6 +51,9 @@ git_project: undefined
 git_version: master # Configure default version to clone, overridable inside the git_apps dictionary within host_vars
 app_relative_path: # set a sub-path you want to sync within a repo. If the repo contains multiple apps in the root directory, just set this to a trailing slash.
 splunk_app_deploy_path: undefined # Path under $SPLUNK_HOME/ to deploy apps to - Note that this may be set in group_vars, host_vars, playbook vars, or inside the git_apps dictionary within host_vars
+# DMC Vars
+splunk_dmc_not_indexer_host_expression: 'all:!indexers'
+splunk_dmc_not_indexers_list: "{{ query('inventory_hostnames', splunk_dmc_not_indexer_host_expression) }}" # List of all inventory items that are not the indexers. If your configuration uses a nonstandard name for hostnames you can replace this with a different list.
 # IDXC Vars
 splunk_idxc_key: mypass4symmkey
 splunk_idxc_rf: 2

--- a/roles/splunk/tasks/configure_dmc.yml
+++ b/roles/splunk/tasks/configure_dmc.yml
@@ -9,7 +9,7 @@
 - name: Configure systems as search peers to be monitored except indexers
   ansible.builtin.shell: |
     {{ splunk_home }}/bin/splunk add search-server https://{{ item }}:{{ splunkd_port }} -auth "{{ splunk_auth }}" -remoteUsername "{{ splunk_admin_username }}" -remotePassword "{{ splunk_admin_password }}"
-  loop: "{{ query('inventory_hostnames', 'all:!indexer') }}"
+  loop: "{{ splunk_dmc_not_indexers_list }}"
   become: true
   become_user: "{{ splunk_nix_user }}"
   no_log: true


### PR DESCRIPTION
Changed the configure_dmc.yml task to use a var for the list of servers that are not indexers to make it more flexible. Fixed `include_task` to be `include_tasks`.