### PR TITLE
Dmc improvements

### DIFF
--- a/roles/splunk/defaults/main.yml
+++ b/roles/splunk/defaults/main.yml
@@ -52,7 +52,7 @@ git_version: master # Configure default version to clone, overridable inside the
 app_relative_path: # set a sub-path you want to sync within a repo. If the repo contains multiple apps in the root directory, just set this to a trailing slash.
 splunk_app_deploy_path: undefined # Path under $SPLUNK_HOME/ to deploy apps to - Note that this may be set in group_vars, host_vars, playbook vars, or inside the git_apps dictionary within host_vars
 # DMC Vars
-splunk_dmc_not_indexer_host_expression: 'all:!indexers'
+splunk_dmc_not_indexer_host_expression: 'all:!indexer'
 splunk_dmc_not_indexers_list: "{{ query('inventory_hostnames', splunk_dmc_not_indexer_host_expression) }}" # List of all inventory items that are not the indexers. If your configuration uses a nonstandard name for hostnames you can replace this with a different list.
 # IDXC Vars
 splunk_idxc_key: mypass4symmkey

--- a/roles/splunk/tasks/configure_dmc.yml
+++ b/roles/splunk/tasks/configure_dmc.yml
@@ -9,10 +9,16 @@
 - name: Configure systems as search peers to be monitored except indexers
   ansible.builtin.shell: |
     {{ splunk_home }}/bin/splunk add search-server https://{{ item }}:{{ splunkd_port }} -auth "{{ splunk_auth }}" -remoteUsername "{{ splunk_admin_username }}" -remotePassword "{{ splunk_admin_password }}"
+  register: result
   loop: "{{ splunk_dmc_not_indexers_list }}"
   become: true
   become_user: "{{ splunk_nix_user }}"
   no_log: true
+  changed_when: result.rc == 0
+  failed_when:
+    # rc 24 means a server with that name is already registered
+    - result.rc != 24
+    - result.rc != 0
 
 - name: Configure monitoring console in auto mode
   community.general.ini_file:


### PR DESCRIPTION
Add changed_when and failed_when directives to the shell module in
    configure_dmc. The task will show a change when the rc is 0 and the
    instance was added successfully. If the command returns a rc of 24 this
    means the instance had already been added, and the result will show ok.
    All other rc will cause a failure.